### PR TITLE
Recreate db after containers are up

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 .PHONY: start
-start: erase build db up ## clean current environment, recreate dependencies and spin up again
+start: erase build up db ## clean current environment, recreate dependencies and spin up again
 
 .PHONY: stop
 stop: ## stop environment


### PR DESCRIPTION
When you execute 'make start' after running composer update it gives an error because the container aren't up.

```
docker-compose exec php sh -lc './bin/console d:d:d --force'
ERROR: No container found for php_1
```

This could be solved from 2 ways. The way i did it or just using 'docker-compose run' instead of 'docker-compose exec'  in the db command.