### PR TITLE
FIX: added casting number of pages and limit query for GetEvents

### DIFF
--- a/src/UI/Http/Rest/Controller/Event/GetEventsController.php
+++ b/src/UI/Http/Rest/Controller/Event/GetEventsController.php
@@ -26,8 +26,8 @@ class GetEventsController extends QueryController
      */
     public function __invoke(Request $request): JsonResponse
     {
-        $page = (int)$request->get('page', 1);
-        $limit = (int)$request->get('limit', 50);
+        $page = (int) $request->get('page', 1);
+        $limit = (int) $request->get('limit', 50);
 
         $query = new GetEventsQuery((int) $page, (int) $limit);
 

--- a/src/UI/Http/Rest/Controller/Event/GetEventsController.php
+++ b/src/UI/Http/Rest/Controller/Event/GetEventsController.php
@@ -26,8 +26,8 @@ class GetEventsController extends QueryController
      */
     public function __invoke(Request $request): JsonResponse
     {
-        $page = $request->get('page', 1);
-        $limit = $request->get('limit', 50);
+        $page = (int)$request->get('page', 1);
+        $limit = (int)$request->get('limit', 50);
 
         $query = new GetEventsQuery((int) $page, (int) $limit);
 

--- a/src/UI/Http/Rest/Controller/Event/GetEventsController.php
+++ b/src/UI/Http/Rest/Controller/Event/GetEventsController.php
@@ -7,6 +7,7 @@ namespace App\UI\Http\Rest\Controller\Event;
 use App\Application\Query\Collection;
 use App\Application\Query\Event\GetEvents\GetEventsQuery;
 use App\UI\Http\Rest\Controller\QueryController;
+use Assert\Assertion;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -26,8 +27,11 @@ class GetEventsController extends QueryController
      */
     public function __invoke(Request $request): JsonResponse
     {
-        $page = (int) $request->get('page', 1);
-        $limit = (int) $request->get('limit', 50);
+        $page = $request->get('page', 1);
+        $limit = $request->get('limit', 50);
+
+        Assertion::integer($page, 'Page number must be an integer');
+        Assertion::integer($limit, 'Limit results must be an integer');
 
         $query = new GetEventsQuery((int) $page, (int) $limit);
 

--- a/tests/UI/Http/Rest/Controller/Events/GetEventsControllerTest.php
+++ b/tests/UI/Http/Rest/Controller/Events/GetEventsControllerTest.php
@@ -44,7 +44,7 @@ class GetEventsControllerTest extends JsonApiTestCase
 
         $this->refreshIndex();
 
-        $this->get('/api/events?limit=1');
+        $this->get('/api/events', ['limit' => 1]);
 
         self::assertEquals(200, $this->client->getResponse()->getStatusCode());
 
@@ -77,7 +77,7 @@ class GetEventsControllerTest extends JsonApiTestCase
 
         $this->refreshIndex();
 
-        $this->get('/api/events?page=2');
+        $this->get('/api/events', ['page' => 2]);
 
         self::assertEquals(200, $this->client->getResponse()->getStatusCode());
 

--- a/tests/UI/Http/Rest/Controller/Events/GetEventsControllerTest.php
+++ b/tests/UI/Http/Rest/Controller/Events/GetEventsControllerTest.php
@@ -40,13 +40,13 @@ class GetEventsControllerTest extends JsonApiTestCase
             'password' => 'password',
         ]);
 
-        self::assertEquals(201, $this->client->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_CREATED, $this->client->getResponse()->getStatusCode());
 
         $this->refreshIndex();
 
         $this->get('/api/events', ['limit' => 1]);
 
-        self::assertEquals(200, $this->client->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
 
         $responseDecoded = json_decode($this->client->getResponse()->getContent(), true);
 
@@ -73,13 +73,13 @@ class GetEventsControllerTest extends JsonApiTestCase
             'password' => 'password',
         ]);
 
-        self::assertEquals(201, $this->client->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_CREATED, $this->client->getResponse()->getStatusCode());
 
         $this->refreshIndex();
 
         $this->get('/api/events', ['page' => 2]);
 
-        self::assertEquals(200, $this->client->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
 
         $responseDecoded = json_decode($this->client->getResponse()->getContent(), true);
 
@@ -88,6 +88,38 @@ class GetEventsControllerTest extends JsonApiTestCase
         self::assertEquals(50, $responseDecoded['meta']['size']);
 
         self::assertFalse(isset($responseDecoded['data']));
+    }
+
+    /**
+     * @test
+     *
+     * @group e2e
+     */
+    public function given_invalid_page_returns_400_status()
+    {
+        $this->get('/api/events', ['page' => 'two']);
+
+        self::assertEquals(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
+
+        $this->get('/api/events?page=two');
+
+        self::assertEquals(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @test
+     *
+     * @group e2e
+     */
+    public function given_invalid_limit_returns_400_status()
+    {
+        $this->get('/api/events', ['limit' => 'three']);
+
+        self::assertEquals(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
+
+        $this->get('/api/events?limit=three');
+
+        self::assertEquals(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
     }
 
     private function refreshIndex()

--- a/tests/UI/Http/Rest/Controller/Events/GetEventsControllerTest.php
+++ b/tests/UI/Http/Rest/Controller/Events/GetEventsControllerTest.php
@@ -63,44 +63,8 @@ class GetEventsControllerTest extends JsonApiTestCase
      *
      * @group e2e
      */
-    public function events_not_present_in_elastic_search_in_other_page()
-    {
-        $uuid = Uuid::uuid4()->toString();
-
-        $this->post('/api/users', [
-            'uuid'     => $uuid,
-            'email'    => 'jo@jo.com',
-            'password' => 'password',
-        ]);
-
-        self::assertEquals(Response::HTTP_CREATED, $this->client->getResponse()->getStatusCode());
-
-        $this->refreshIndex();
-
-        $this->get('/api/events', ['page' => 2]);
-
-        self::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
-
-        $responseDecoded = json_decode($this->client->getResponse()->getContent(), true);
-
-        self::assertEquals(1, $responseDecoded['meta']['total']);
-        self::assertEquals(2, $responseDecoded['meta']['page']);
-        self::assertEquals(50, $responseDecoded['meta']['size']);
-
-        self::assertFalse(isset($responseDecoded['data']));
-    }
-
-    /**
-     * @test
-     *
-     * @group e2e
-     */
     public function given_invalid_page_returns_400_status()
     {
-        $this->get('/api/events', ['page' => 'two']);
-
-        self::assertEquals(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
-
         $this->get('/api/events?page=two');
 
         self::assertEquals(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
@@ -113,10 +77,6 @@ class GetEventsControllerTest extends JsonApiTestCase
      */
     public function given_invalid_limit_returns_400_status()
     {
-        $this->get('/api/events', ['limit' => 'three']);
-
-        self::assertEquals(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
-
         $this->get('/api/events?limit=three');
 
         self::assertEquals(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());

--- a/tests/UI/Http/Rest/Controller/Events/GetEventsControllerTest.php
+++ b/tests/UI/Http/Rest/Controller/Events/GetEventsControllerTest.php
@@ -33,7 +33,7 @@ class GetEventsControllerTest extends JsonApiTestCase
     public function events_should_be_present_in_elastic_search()
     {
         $this->post('/api/users', [
-            'uuid'     => $uuid = Uuid::uuid4()->toString(),
+            'uuid'     => Uuid::uuid4()->toString(),
             'email'    => 'jo@jo.com',
             'password' => 'password',
         ]);
@@ -42,7 +42,7 @@ class GetEventsControllerTest extends JsonApiTestCase
 
         $this->refreshIndex();
 
-        $this->get('/api/events');
+        $this->get('/api/events?limit=1');
 
         self::assertEquals(200, $this->client->getResponse()->getStatusCode());
 

--- a/tests/UI/Http/Rest/Controller/JsonApiTestCase.php
+++ b/tests/UI/Http/Rest/Controller/JsonApiTestCase.php
@@ -23,12 +23,12 @@ abstract class JsonApiTestCase extends WebTestCase
         );
     }
 
-    protected function get(string $uri)
+    protected function get(string $uri, array $parameters = [])
     {
         $this->client->request(
             'GET',
             $uri,
-            [],
+            $parameters,
             [],
             [
                 'CONTENT_TYPE' => 'application/json',

--- a/tests/UI/Http/Rest/Controller/User/ChangeEmailControllerTest.php
+++ b/tests/UI/Http/Rest/Controller/User/ChangeEmailControllerTest.php
@@ -9,6 +9,7 @@ use App\Tests\Infrastructure\Share\Event\EventCollectorListener;
 use App\Tests\UI\Http\Rest\Controller\JsonApiTestCase;
 use Broadway\Domain\DomainMessage;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Response;
 
 class ChangeEmailControllerTest extends JsonApiTestCase
 {
@@ -25,13 +26,13 @@ class ChangeEmailControllerTest extends JsonApiTestCase
             'password' => 'password',
         ]);
 
-        self::assertEquals(201, $this->client->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_CREATED, $this->client->getResponse()->getStatusCode());
 
         $this->post('/api/users/' . $uuid . '/email', [
             'email' => 'weba@jo.com',
         ]);
 
-        self::assertEquals(200, $this->client->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
 
         /** @var EventCollectorListener $eventCollector */
         $eventCollector = $this->client->getContainer()->get(EventCollectorListener::class);
@@ -55,12 +56,12 @@ class ChangeEmailControllerTest extends JsonApiTestCase
             'password' => 'password',
         ]);
 
-        self::assertEquals(201, $this->client->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_CREATED, $this->client->getResponse()->getStatusCode());
 
         $this->post('/api/users/' . $uuid . '/email', [
             'email' => 'webajo.com',
         ]);
 
-        self::assertEquals(400, $this->client->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
     }
 }

--- a/tests/UI/Http/Rest/Controller/User/GetUserByEmailControllerTest.php
+++ b/tests/UI/Http/Rest/Controller/User/GetUserByEmailControllerTest.php
@@ -12,6 +12,7 @@ use App\Tests\Infrastructure\Share\Event\EventCollectorListener;
 use App\Tests\UI\Http\Rest\Controller\JsonApiTestCase;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Response;
 
 class GetUserByEmailControllerTest extends JsonApiTestCase
 {
@@ -24,7 +25,7 @@ class GetUserByEmailControllerTest extends JsonApiTestCase
     {
         $this->get('/api/user/asd@');
 
-        self::assertEquals(400, $this->client->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
 
         /** @var EventCollectorListener $eventCollector */
         $eventCollector = $this->client->getContainer()->get(EventCollectorListener::class);
@@ -43,7 +44,7 @@ class GetUserByEmailControllerTest extends JsonApiTestCase
     {
         $this->get('/api/user/asd@asd.asd');
 
-        self::assertEquals(404, $this->client->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_NOT_FOUND, $this->client->getResponse()->getStatusCode());
 
         /** @var EventCollectorListener $eventCollector */
         $eventCollector = $this->client->getContainer()->get(EventCollectorListener::class);
@@ -64,7 +65,7 @@ class GetUserByEmailControllerTest extends JsonApiTestCase
 
         $this->get('/api/user/' . $emailString);
 
-        self::assertEquals(200, $this->client->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
 
         /** @var EventCollectorListener $eventCollector */
         $eventCollector = $this->client->getContainer()->get(EventCollectorListener::class);

--- a/tests/UI/Http/Rest/Controller/User/SignUpControllerTest.php
+++ b/tests/UI/Http/Rest/Controller/User/SignUpControllerTest.php
@@ -7,6 +7,7 @@ use App\Tests\Infrastructure\Share\Event\EventCollectorListener;
 use App\Tests\UI\Http\Rest\Controller\JsonApiTestCase;
 use Broadway\Domain\DomainMessage;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Response;
 
 class SignUpControllerTest extends JsonApiTestCase
 {
@@ -23,7 +24,7 @@ class SignUpControllerTest extends JsonApiTestCase
             'password' => 'oaisudaosudoaudo',
         ]);
 
-        self::assertEquals(201, $this->client->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_CREATED, $this->client->getResponse()->getStatusCode());
 
         /** @var EventCollectorListener $eventCollector */
         $eventCollector = $this->client->getContainer()->get(EventCollectorListener::class);
@@ -50,7 +51,7 @@ class SignUpControllerTest extends JsonApiTestCase
             'email' => 'invalid email',
         ]);
 
-        self::assertEquals(400, $this->client->getResponse()->getStatusCode());
+        self::assertEquals(Response::HTTP_BAD_REQUEST, $this->client->getResponse()->getStatusCode());
 
         /** @var EventCollectorListener $eventCollector */
         $eventCollector = $this->client->getContainer()->get(EventCollectorListener::class);

--- a/tests/UI/Http/Web/Controller/ProfileControllerTest.php
+++ b/tests/UI/Http/Web/Controller/ProfileControllerTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\UI\Http\Web\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 class ProfileControllerTest extends WebTestCase
 {
@@ -22,7 +23,7 @@ class ProfileControllerTest extends WebTestCase
 
         /** @var RedirectResponse $response */
         $response = $client->getResponse();
-        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
         $this->assertContains('/sign-in', $response->getTargetUrl());
     }
 }


### PR DESCRIPTION
Added query parameter for GetEvents action to fetch only one record. It coverage additional method in tests and shoved me an exception in building `GetEventsQuery`. The problem occurred when `$request->get('limit', 1)` gives me string not default integer value. :)