### PR TITLE
Rename UserCollectionInterface

### DIFF
--- a/src/Application/Command/User/SignIn/SignInHandler.php
+++ b/src/Application/Command/User/SignIn/SignInHandler.php
@@ -6,7 +6,7 @@ namespace App\Application\Command\User\SignIn;
 
 use App\Application\Command\CommandHandlerInterface;
 use App\Domain\User\Exception\InvalidCredentialsException;
-use App\Domain\User\Repository\UserCollectionInterface;
+use App\Domain\User\Repository\CheckUserByEmailInterface;
 use App\Domain\User\Repository\UserRepositoryInterface;
 use App\Domain\User\ValueObject\Email;
 use Ramsey\Uuid\UuidInterface;
@@ -35,7 +35,7 @@ class SignInHandler implements CommandHandlerInterface
         return $uuid;
     }
 
-    public function __construct(UserRepositoryInterface $userStore, UserCollectionInterface $userCollection)
+    public function __construct(UserRepositoryInterface $userStore, CheckUserByEmailInterface $userCollection)
     {
         $this->userStore = $userStore;
         $this->userCollection = $userCollection;
@@ -47,7 +47,7 @@ class SignInHandler implements CommandHandlerInterface
     private $userStore;
 
     /**
-     * @var UserCollectionInterface
+     * @var CheckUserByEmailInterface
      */
     private $userCollection;
 }

--- a/src/Domain/User/Factory/UserFactory.php
+++ b/src/Domain/User/Factory/UserFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Domain\User\Factory;
 
 use App\Domain\User\Exception\EmailAlreadyExistException;
-use App\Domain\User\Repository\UserCollectionInterface;
+use App\Domain\User\Repository\CheckUserByEmailInterface;
 use App\Domain\User\User;
 use App\Domain\User\ValueObject\Auth\Credentials;
 use Ramsey\Uuid\UuidInterface;
@@ -21,13 +21,13 @@ class UserFactory
         return User::create($uuid, $credentials);
     }
 
-    public function __construct(UserCollectionInterface $userCollection)
+    public function __construct(CheckUserByEmailInterface $userCollection)
     {
         $this->userCollection = $userCollection;
     }
 
     /**
-     * @var UserCollectionInterface
+     * @var CheckUserByEmailInterface
      */
     private $userCollection;
 }

--- a/src/Domain/User/Repository/CheckUserByEmailInterface.php
+++ b/src/Domain/User/Repository/CheckUserByEmailInterface.php
@@ -5,7 +5,7 @@ namespace App\Domain\User\Repository;
 use App\Domain\User\ValueObject\Email;
 use Ramsey\Uuid\UuidInterface;
 
-interface UserCollectionInterface
+interface CheckUserByEmailInterface
 {
     public function existsEmail(Email $email): ?UuidInterface;
 }

--- a/src/Infrastructure/User/Query/Mysql/MysqlUserReadModelRepository.php
+++ b/src/Infrastructure/User/Query/Mysql/MysqlUserReadModelRepository.php
@@ -6,14 +6,14 @@ namespace App\Infrastructure\User\Query\Mysql;
 
 use App\Domain\User\Query\Projections\UserViewInterface;
 use App\Domain\User\Query\Repository\UserReadModelRepositoryInterface;
-use App\Domain\User\Repository\UserCollectionInterface;
+use App\Domain\User\Repository\CheckUserByEmailInterface;
 use App\Domain\User\ValueObject\Email;
 use App\Infrastructure\Share\Query\Repository\MysqlRepository;
 use App\Infrastructure\User\Query\Projections\UserView;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\UuidInterface;
 
-class MysqlUserReadModelRepository extends MysqlRepository implements UserReadModelRepositoryInterface, UserCollectionInterface
+class MysqlUserReadModelRepository extends MysqlRepository implements UserReadModelRepositoryInterface, CheckUserByEmailInterface
 {
     /**
      * @param UuidInterface $uuid

--- a/tests/Domain/User/Factory/UserFactoryTest.php
+++ b/tests/Domain/User/Factory/UserFactoryTest.php
@@ -6,7 +6,7 @@ namespace App\Tests\Domain\User\Factory;
 
 use App\Domain\User\Exception\EmailAlreadyExistException;
 use App\Domain\User\Factory\UserFactory;
-use App\Domain\User\Repository\UserCollectionInterface;
+use App\Domain\User\Repository\CheckUserByEmailInterface;
 use App\Domain\User\ValueObject\Auth\Credentials;
 use App\Domain\User\ValueObject\Auth\HashedPassword;
 use App\Domain\User\ValueObject\Email;
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 
-class UserFactoryTest extends TestCase implements UserCollectionInterface
+class UserFactoryTest extends TestCase implements CheckUserByEmailInterface
 {
     /**
      * @test


### PR DESCRIPTION
As mentioned by @jorge07 [here](https://github.com/jorge07/symfony-4-es-cqrs-boilerplate/issues/47#issuecomment-406043824)

Renaming this interface should emphasize that it should only be implemented to check is a user with a certain email is already registered.

Resolve #54 