### PR TITLE
Fix DBAL Event store config.

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,7 +6,7 @@ parameters:
       - '%env(ELASTIC_HOST)%'
 
   env(ELASTIC_HOST): 'elasticsearch:9200'
-  
+
 services:
     _defaults:
         autowire: true
@@ -53,7 +53,7 @@ services:
           - '@broadway.serializer.payload'
           - '@broadway.serializer.metadata'
           - 'events'
-          - 'false'
+          - true
           - '@broadway.uuid.converter'
 
     ### UI


### PR DESCRIPTION
Wrong config in DBALEventStore. We were passing in the construct `'false'` but the constructor parameter is a boolean and it was acting as `true`