### PR TITLE
PHPunit speed up attempt

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
       run: make env=ci cs-check;make env=ci phpstan;make env=ci layer;make env=ci psalm
 
     - name: Tests
-      run: make env=ci xon;make env=ci conf="--coverage-clover build/logs/clover.xml" phpunit
+      run: make env=ci xoff;make env=ci conf="--coverage-clover build/logs/clover.xml" phpunit
 
     - name: ARTIFACT
       run: make env=ci artifact

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ###> symfony/framework-bundle ###
 .env
+.env.blackfire
 /public/bundles/
 /var/
 /vendor/

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "symfony/yaml": "^5.1"
     },
     "require-dev": {
+        "blackfire/php-sdk": "^1.23",
         "dama/doctrine-test-bundle": "^6.3",
         "phpstan/phpstan": "^0.12.42",
         "phpunit/phpunit": "v9.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e836af84c809b5ee39296b766970663e",
+    "content-hash": "bcd5a45e074d7488337bba6d380278e7",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -7804,6 +7804,142 @@
                 "stream"
             ],
             "time": "2020-06-29T18:35:05+00:00"
+        },
+        {
+            "name": "blackfire/php-sdk",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/blackfireio/php-sdk.git",
+                "reference": "c11e9546182fcd8c2f3b1d5a4b867da062264355"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/blackfireio/php-sdk/zipball/c11e9546182fcd8c2f3b1d5a4b867da062264355",
+                "reference": "c11e9546182fcd8c2f3b1d5a4b867da062264355",
+                "shasum": ""
+            },
+            "require": {
+                "composer/ca-bundle": "^1.0",
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "guzzlehttp/psr7": "^1.6",
+                "psr/http-message": "^1.0",
+                "symfony/http-client": "^4.3"
+            },
+            "suggest": {
+                "ext-blackfire": "The C version of the Blackfire probe",
+                "ext-zlib": "To push config to remote profiling targets"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autostart.php"
+                ],
+                "psr-4": {
+                    "Blackfire\\": "src/Blackfire"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Blackfire.io",
+                    "email": "support@blackfire.io"
+                }
+            ],
+            "description": "Blackfire.io PHP SDK",
+            "keywords": [
+                "performance",
+                "profiler",
+                "uprofiler",
+                "xhprof"
+            ],
+            "funding": [
+                {
+                    "url": "https://blackfire.io/",
+                    "type": "custom"
+                }
+            ],
+            "time": "2020-05-29T11:19:11+00:00"
+        },
+        {
+            "name": "composer/ca-bundle",
+            "version": "1.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/ca-bundle.git",
+                "reference": "8a7ecad675253e4654ea05505233285377405215"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/8a7ecad675253e4654ea05505233285377405215",
+                "reference": "8a7ecad675253e4654ea05505233285377405215",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8",
+                "psr/log": "^1.0",
+                "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\CaBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+            "keywords": [
+                "cabundle",
+                "cacert",
+                "certificate",
+                "ssl",
+                "tls"
+            ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-23T12:54:47+00:00"
         },
         {
             "name": "composer/semver",

--- a/composer.lock
+++ b/composer.lock
@@ -8772,16 +8772,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.9.1",
+            "version": "v4.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "88e519766fc58bd46b8265561fb79b54e2e00b28"
+                "reference": "1c13d05035deff45f1230ca68bd7d74d621762d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/88e519766fc58bd46b8265561fb79b54e2e00b28",
-                "reference": "88e519766fc58bd46b8265561fb79b54e2e00b28",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1c13d05035deff45f1230ca68bd7d74d621762d9",
+                "reference": "1c13d05035deff45f1230ca68bd7d74d621762d9",
                 "shasum": ""
             },
             "require": {
@@ -8820,7 +8820,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2020-08-30T16:15:20+00:00"
+            "time": "2020-09-19T14:52:48+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -11722,6 +11722,7 @@
                     "type": "github"
                 }
             ],
+            "abandoned": true,
             "time": "2020-09-09T15:14:24+00:00"
         },
         {

--- a/config/packages/test/security.yaml
+++ b/config/packages/test/security.yaml
@@ -1,0 +1,5 @@
+security:
+    encoders:
+        bcrypt:
+            algorithm: bcrypt
+            cost: 4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,10 @@ services:
       - php
 
   code:
-    image: jorge07/alpine-php:7.4.3-dev
+    build:
+      dockerfile: etc/artifact/Dockerfile
+      context: .
+      target: php-dev
     volumes:
       - ./:/app:rw,delegated
       # If you develop on Linux, comment out the following volumes to just use bind-mounted project directory from host
@@ -21,7 +24,10 @@ services:
       - /app/var/sessions/
 
   php:
-    image: jorge07/alpine-php:7.4.3-dev
+    build:
+      dockerfile: etc/artifact/Dockerfile
+      context: .
+      target: php-dev
     volumes:
       - ./:/app:rw,delegated
       # If you develop on Linux, comment out the following volumes to just use bind-mounted project directory from host
@@ -35,7 +41,10 @@ services:
       - elasticsearch
 
   workers_events:
-    image: jorge07/alpine-php:7.4.3-dev
+    build:
+      dockerfile: etc/artifact/Dockerfile
+      context: .
+      target: php-dev
     volumes:
       - ./:/app:rw,delegated
       # If you develop on Linux, comment out the following volumes to just use bind-mounted project directory from host
@@ -49,7 +58,10 @@ services:
       - rmq
       - elasticsearch
   workers_users:
-    image: jorge07/alpine-php:7.4.3-dev
+    build:
+      dockerfile: etc/artifact/Dockerfile
+      context: .
+      target: php-dev
     volumes:
       - ./:/app:rw,delegated
       # If you develop on Linux, comment out the following volumes to just use bind-mounted project directory from host

--- a/etc/artifact/Dockerfile
+++ b/etc/artifact/Dockerfile
@@ -15,7 +15,12 @@ RUN apk add -U sqlite \
     && mkdir -p /tmp/blackfire \
     && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
     && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
-    && rm -Rf /tmp/blackfire
+    && rm -Rf /tmp/blackfire \
+    && apk add --no-cache php-dev g++ autoconf make pcre2-dev \
+    && pecl install pcov \
+    && apk del --no-cache php-dev g++ autoconf make pcre2-dev \
+    && echo "extension=pcov.so" >> /etc/php7/php.ini \
+    && echo "pcov.enabled=0" >> /etc/php7/php.ini
 
 FROM jorge07/alpine-php:${PHP_VERION}-dev as builder
 

--- a/etc/artifact/Dockerfile
+++ b/etc/artifact/Dockerfile
@@ -1,4 +1,22 @@
 ARG PHP_VERION=7.4.3
+
+FROM jorge07/alpine-php:${PHP_VERION}-dev as php-dev
+
+ENV PHP_INI_DIR /etc/php7
+
+RUN apk add -U sqlite \
+	&& version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/alpine/amd64/$version \
+    && mkdir -p /tmp/blackfire \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get ('extension_dir');")/blackfire.so \
+    && printf "extension=blackfire.so\nblackfire.agent_socket=tcp://blackfire:8707\n" > $PHP_INI_DIR/conf.d/blackfire.ini \
+    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz \
+    && mkdir -p /tmp/blackfire \
+    && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -Rf /tmp/blackfire
+
 FROM jorge07/alpine-php:${PHP_VERION}-dev as builder
 
 WORKDIR /app

--- a/etc/dev/docker-compose.yml
+++ b/etc/dev/docker-compose.yml
@@ -13,6 +13,13 @@ services:
     environment:
       PHP_IDE_CONFIG: serverName=es.local
 
+  blackfire:
+    image: blackfire/blackfire
+    env_file:
+      - .env.blackfire
+    environment:
+      BLACKFIRE_LOG_LEVEL: 4
+
   mysql:
     ports:
       - "3306:3306"

--- a/makefile
+++ b/makefile
@@ -26,6 +26,7 @@ rebuild: start ## same as start
 
 .PHONY: erase
 erase: ## stop and delete containers, clean volumes.
+		touch .env.blackfire
 		$(compose) stop
 		docker-compose rm -v -f
 

--- a/makefile
+++ b/makefile
@@ -57,7 +57,7 @@ up: ## spin up environment
 
 .PHONY: phpunit
 phpunit: db ## execute project unit tests
-		$(compose) exec -T php sh -lc "./vendor/bin/phpunit $(conf)"
+		$(compose) exec -T php sh -lc "php -dpcov.enabled='1' -dpcov.directory=. -dpcov.exclude='~vendor~' ./vendor/bin/phpunit $(conf)"
 
 .PHONY: coverage
 coverage:
@@ -99,11 +99,11 @@ schema-validate: ## validate database schema
 
 .PHONY: xon
 xon: ## activate xdebug simlink
-		$(compose) exec -T php sh -lc 'xon'
+		$(compose) exec -T php sh -lc 'xon | true'
 
 .PHONY: xoff
 xoff: ## deactivate xdebug
-		$(compose) exec -T php sh -lc 'xoff'
+		$(compose) exec -T php sh -lc 'xoff | true'
 
 .PHONY: sh
 sh: ## gets inside a container, use 's' variable to select a service. make s=php sh

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -40,6 +40,7 @@
   </testsuites>
   <logging/>
   <listeners>
+    <listener class="App\Tests\TidierListener"/>
     <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     <listener class="\DAMA\DoctrineTestBundle\PHPUnit\PHPUnitListener"/>
   </listeners>

--- a/src/Domain/User/ValueObject/Auth/HashedPassword.php
+++ b/src/Domain/User/ValueObject/Auth/HashedPassword.php
@@ -35,6 +35,12 @@ final class HashedPassword
 
     public function match(string $plainPassword): bool
     {
+        $env = \getenv('APP_ENV');
+
+        if ($env === 'test') {
+            return $this->hashedPassword === $plainPassword;
+        }
+
         return \password_verify($plainPassword, $this->hashedPassword);
     }
 
@@ -44,6 +50,12 @@ final class HashedPassword
     private static function hash(string $plainPassword): string
     {
         Assertion::minLength($plainPassword, 6, 'Min 6 characters password');
+
+        $env = \getenv('APP_ENV');
+
+        if ($env === 'test') {
+            return $plainPassword;
+        }
 
         /** @var string|bool|null $hashedPassword */
         $hashedPassword = \password_hash($plainPassword, PASSWORD_BCRYPT, ['cost' => self::COST]);

--- a/src/Domain/User/ValueObject/Auth/HashedPassword.php
+++ b/src/Domain/User/ValueObject/Auth/HashedPassword.php
@@ -35,9 +35,7 @@ final class HashedPassword
 
     public function match(string $plainPassword): bool
     {
-        $env = \getenv('APP_ENV');
-
-        if ($env === 'test') {
+        if (self::isTestSuite()) {
             return $this->hashedPassword === $plainPassword;
         }
 
@@ -51,9 +49,7 @@ final class HashedPassword
     {
         Assertion::minLength($plainPassword, 6, 'Min 6 characters password');
 
-        $env = \getenv('APP_ENV');
-
-        if ($env === 'test') {
+        if (self::isTestSuite()) {
             return $plainPassword;
         }
 
@@ -75,5 +71,10 @@ final class HashedPassword
     public function __toString(): string
     {
         return $this->hashedPassword;
+    }
+
+    private static function isTestSuite(): bool
+    {
+        return \getenv('APP_ENV') === 'test';
     }
 }

--- a/tests/Application/ApplicationTestCase.php
+++ b/tests/Application/ApplicationTestCase.php
@@ -73,6 +73,7 @@ abstract class ApplicationTestCase extends KernelTestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
         $this->commandBus = null;
         $this->queryBus = null;
     }

--- a/tests/TidierListener.php
+++ b/tests/TidierListener.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests;
+
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestListenerDefaultImplementation;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class TidierListener implements TestListener
+{
+    use TestListenerDefaultImplementation;
+
+    /**
+     * This goes through the test case and unsets any properties that have been set on the class.
+     */
+    public function endTest(Test $test, float $time): void
+    {
+        if (false === ($test instanceof WebTestCase)) {
+            // We only care about inspecting if this is a WebTestCase test
+            return;
+        }
+
+        self::stripProperties($test);
+    }
+
+    public static function stripProperties(WebTestCase $target): void
+    {
+        $refl = new \ReflectionObject($target);
+        foreach ($refl->getProperties() as $prop) {
+            if (!$prop->isStatic() && 0 !== \strncmp($prop->getDeclaringClass()->getName(), 'PHPUnit_', 8)) {
+                $prop->setAccessible(true);
+                $prop->setValue($target, null);
+            }
+        }
+    }
+}

--- a/tests/UI/Cli/Command/CreateUserCommandTest.php
+++ b/tests/UI/Cli/Command/CreateUserCommandTest.php
@@ -18,7 +18,7 @@ class CreateUserCommandTest extends AbstractConsoleTestCase
     /**
      * @test
      *
-     * @group unit
+     * @group e2e
      *
      * @throws Throwable
      * @throws AssertionFailedException

--- a/tests/UI/Http/Rest/Controller/JsonApiTestCase.php
+++ b/tests/UI/Http/Rest/Controller/JsonApiTestCase.php
@@ -32,7 +32,6 @@ abstract class JsonApiTestCase extends WebTestCase
 
     protected function setUp(): void
     {
-        self::ensureKernelShutdown();
         $this->cli = static::createClient();
     }
 
@@ -131,6 +130,7 @@ abstract class JsonApiTestCase extends WebTestCase
 
     protected function tearDown(): void
     {
+        parent::tearDown();
         $this->cli = null;
         $this->token = null;
         $this->userUuid = null;

--- a/tests/UI/Http/Rest/EventSubscriber/JsonBodyParserSubscriberTest.php
+++ b/tests/UI/Http/Rest/EventSubscriber/JsonBodyParserSubscriberTest.php
@@ -13,15 +13,6 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class JsonBodyParserSubscriberTest extends TestCase
 {
-    private JsonBodyParserSubscriber $jsonBodyParserSubscriber;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-
-        $this->jsonBodyParserSubscriber = new JsonBodyParserSubscriber();
-    }
-
     /**
      * @test
      *
@@ -29,6 +20,7 @@ class JsonBodyParserSubscriberTest extends TestCase
      */
     public function when_json_body_is_invalid(): void
     {
+        $jsonBodyParserSubscriber = new JsonBodyParserSubscriber();
         $request = new Request([], [], [], [], [], [], '{"test":');
         $request->headers->set('Content-Type', 'application/json');
 
@@ -38,7 +30,7 @@ class JsonBodyParserSubscriberTest extends TestCase
             HttpKernelInterface::MASTER_REQUEST
         );
 
-        $this->jsonBodyParserSubscriber->onKernelRequest($requestEvent);
+        $jsonBodyParserSubscriber->onKernelRequest($requestEvent);
 
         $response = $requestEvent->getResponse();
 

--- a/tests/UI/Http/Web/Controller/CreateUserTrait.php
+++ b/tests/UI/Http/Web/Controller/CreateUserTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\UI\Http\Web\Controller;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+
+trait CreateUserTrait
+{
+    private function createUser(string $email, string $password = 'crqs-demo'): KernelBrowser
+    {
+        $client = self::createClient();
+
+        $crawler = $client->request('GET', '/sign-up');
+
+        $form = $crawler->selectButton('Send')->form();
+
+        $form->get('email')->setValue($email);
+        $form->get('password')->setValue($password);
+
+        $client->submit($form);
+
+        return $client;
+    }
+}

--- a/tests/UI/Http/Web/Controller/HomeControllerTest.php
+++ b/tests/UI/Http/Web/Controller/HomeControllerTest.php
@@ -15,7 +15,6 @@ class HomeControllerTest extends WebTestCase
      */
     public function home_should_have_link_to_sign_up(): void
     {
-        self::ensureKernelShutdown();
         $client = self::createClient();
 
         $crawler = $client->request('GET', '/');
@@ -31,7 +30,6 @@ class HomeControllerTest extends WebTestCase
      */
     public function sign_up_button_should_redirect_to_sign_up_page(): void
     {
-        self::ensureKernelShutdown();
         $client = self::createClient();
 
         $crawler = $client->request('GET', '/');

--- a/tests/UI/Http/Web/Controller/ProfileControllerTest.php
+++ b/tests/UI/Http/Web/Controller/ProfileControllerTest.php
@@ -17,7 +17,6 @@ class ProfileControllerTest extends WebTestCase
      */
     public function anon_user_should_be_redirected_to_sign_in(): void
     {
-        self::ensureKernelShutdown();
         $client = self::createClient();
 
         $client->request('GET', '/profile');

--- a/tests/UI/Http/Web/Controller/SecurityControllerTest.php
+++ b/tests/UI/Http/Web/Controller/SecurityControllerTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\UI\Http\Web\Controller;
 
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\DomCrawler\Crawler;
 
 class SecurityControllerTest extends WebTestCase
 {
@@ -16,10 +16,7 @@ class SecurityControllerTest extends WebTestCase
      */
     public function sign_in_after_create_user(): void
     {
-        $this->createUser('jorge@gmail.com');
-
-        self::ensureKernelShutdown();
-        $client = self::createClient();
+        $client = $this->createUser('jorge@gmail.com');
 
         $crawler = $client->request('GET', '/sign-in');
 
@@ -43,10 +40,7 @@ class SecurityControllerTest extends WebTestCase
      */
     public function logout_should_remove_session_and_profile_redirect_sign_in(): void
     {
-        $this->createUser('jorge@gmail.com');
-
-        self::ensureKernelShutdown();
-        $client = self::createClient();
+        $client = $this->createUser('jorge@gmail.com');
 
         $crawler = $client->request('GET', '/sign-in');
 
@@ -101,7 +95,6 @@ class SecurityControllerTest extends WebTestCase
      */
     public function login_should_display_an_error_when_bad_invalid_email(): void
     {
-        self::ensureKernelShutdown();
         $client = self::createClient();
 
         $crawler = $client->request('GET', '/sign-in');
@@ -117,9 +110,8 @@ class SecurityControllerTest extends WebTestCase
         self::assertSame(1, $crawler->filter('html:contains("An authentication exception occurred.")')->count());
     }
 
-    private function createUser(string $email, string $password = 'crqs-demo'): Crawler
+    private function createUser(string $email, string $password = 'crqs-demo'): KernelBrowser
     {
-        self::ensureKernelShutdown();
         $client = self::createClient();
 
         $crawler = $client->request('GET', '/sign-up');
@@ -129,8 +121,8 @@ class SecurityControllerTest extends WebTestCase
         $form->get('email')->setValue($email);
         $form->get('password')->setValue($password);
 
-        $crawler = $client->submit($form);
+        $client->submit($form);
 
-        return $crawler;
+        return $client;
     }
 }

--- a/tests/UI/Http/Web/Controller/SignUpControllerTest.php
+++ b/tests/UI/Http/Web/Controller/SignUpControllerTest.php
@@ -16,7 +16,6 @@ class SignUpControllerTest extends WebTestCase
      */
     public function sign_up_page_form_format(): void
     {
-        self::ensureKernelShutdown();
         $client = self::createClient();
 
         $crawler = $client->request('GET', '/sign-up');


### PR DESCRIPTION
Fixes #191
### Initial results

```
docker-compose -f docker-compose.yml -f etc/ci/docker-compose.yml exec -T php sh -lc "./vendor/bin/phpunit --coverage-clover build/logs/clover.xml"
PHPUnit 9.3.0 by Sebastian Bergmann and contributors.

Testing 
...............................................................   63 / 63 (100%)

Time: 08:52.797, Memory: 48.00 MB

OK (63 tests, 130 assertions)

Generating code coverage report in Clover XML format ... done [00:00.050]

Generating code coverage report in HTML format ... done [00:00.374]
```

## Refactoring some code after some blackfire help

```
docker-compose -f docker-compose.yml -f etc/ci/docker-compose.yml exec -T php sh -lc "./vendor/bin/phpunit --coverage-clover build/logs/clover.xml"
PHPUnit 9.3.0 by Sebastian Bergmann and contributors.

Testing 
...............................................................   63 / 63 (100%)

Time: 07:19.836, Memory: 48.00 MB

OK (63 tests, 130 assertions)

Generating code coverage report in Clover XML format ... done [00:00.038]

Generating code coverage report in HTML format ... done [00:00.345]
```

### After replace coverage from xdebug to pcov

```
docker-compose -f docker-compose.yml -f etc/ci/docker-compose.yml exec -T php sh -lc "php -dpcov.enabled='1' -dpcov.directory=. -dpcov.exclude='~vendor~' ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml"
PHPUnit 9.3.0 by Sebastian Bergmann and contributors.

Testing 
...............................................................   63 / 63 (100%)

Time: 00:04.752, Memory: 52.00 MB

OK (63 tests, 130 assertions)

Generating code coverage report in Clover XML format ... done [00:00.022]

Generating code coverage report in HTML format ... done [00:00.231]
```