### PR TITLE
Fix issue with swagger declarations and change annotations to attributes

### DIFF
--- a/src/UI/Http/Rest/Controller/Auth/CheckController.php
+++ b/src/UI/Http/Rest/Controller/Auth/CheckController.php
@@ -7,11 +7,12 @@ namespace UI\Http\Rest\Controller\Auth;
 use App\User\Application\Command\SignIn\SignInCommand;
 use App\User\Application\Query\Auth\GetToken\GetTokenQuery;
 use App\User\Domain\Exception\InvalidCredentialsException;
+use Symfony\Component\HttpFoundation\Response;
 use UI\Http\Rest\Controller\CommandQueryController;
 use UI\Http\Rest\Response\OpenApi;
 use Assert\Assertion;
 use Assert\AssertionFailedException;
-use OpenApi\Annotations as OA;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 use Throwable;
@@ -19,39 +20,39 @@ use Throwable;
 final class CheckController extends CommandQueryController
 {
     /**
-     * @OA\Response(
-     *     response=200,
-     *     description="Login success",
-     *     @OA\JsonContent(
-     *        type="object",
-     *        @OA\Property(
-     *          property="token", type="string"
-     *        )
-     *     )
-     * )
-     * @OA\Response(
-     *     response=400,
-     *     description="Bad request"
-     * )
-     * @OA\Response(
-     *     response=401,
-     *     description="Bad credentials"
-     * )
-     * @OA\RequestBody(
-     *     @OA\JsonContent(
-     *         type="object",
-     *         @OA\Property(property="_password", type="string"),
-     *         @OA\Property(property="_username", type="string")
-     *     )
-     * )
-     *
-     * @OA\Tag(name="Auth")
-     *
      * @throws AssertionFailedException
      * @throws InvalidCredentialsException
      * @throws Throwable
      */
-    #[Route(path: '/auth_check', name: 'auth_check', methods: ['POST'], requirements: ['_username' => '\w+', '_password' => '\w+'])]
+    #[OA\Response(
+        response: Response::HTTP_OK,
+        description: 'Login success',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'token', type: 'string'),
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Response(
+        response: Response::HTTP_BAD_REQUEST,
+        description: 'Bad request',
+    )]
+    #[OA\Response(
+        response: Response::HTTP_UNAUTHORIZED,
+        description: 'Bad credentials',
+    )]
+    #[OA\RequestBody(
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: '_password', type: 'string'),
+                new OA\Property(property: '_username', type: 'string'),
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Tag(name: 'Auth')]
+    #[Route(path: '/auth_check', name: 'auth_check', requirements: ['_username' => '\w+', '_password' => '\w+'], methods: [Request::METHOD_POST])]
     public function __invoke(Request $request): OpenApi
     {
         $username = (string) $request->request->get('_username');

--- a/src/UI/Http/Rest/Controller/Event/GetEventsController.php
+++ b/src/UI/Http/Rest/Controller/Event/GetEventsController.php
@@ -29,19 +29,6 @@ class GetEventsController extends QueryController
      *     response=400,
      *     description="Bad request",
      *     @OA\JsonContent(ref="#/components/schemas/Error")
-     *
-     * )
-     * @OA\Response(
-     *     response=409,
-     *     description="Conflict"
-     * )
-     *
-     * @OA\Parameter(ref="#/components/parameters/page")
-     * @OA\Parameter(ref="#/components/parameters/limit")
-     *
-     * @OA\Tag(name="Events")
-     *
-     * @Security(name="Bearer")
      * )
      * @OA\Response(
      *     response=409,

--- a/src/UI/Http/Rest/Controller/Event/GetEventsController.php
+++ b/src/UI/Http/Rest/Controller/Event/GetEventsController.php
@@ -6,12 +6,13 @@ namespace UI\Http\Rest\Controller\Event;
 
 use App\Shared\Application\Query\Collection;
 use App\Shared\Application\Query\Event\GetEvents\GetEventsQuery;
+use Symfony\Component\HttpFoundation\Response;
 use UI\Http\Rest\Controller\QueryController;
 use UI\Http\Rest\Response\OpenApi;
 use Assert\Assertion;
 use Assert\AssertionFailedException;
 use Nelmio\ApiDocBundle\Annotation\Security;
-use OpenApi\Annotations as OA;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 use Throwable;
@@ -19,33 +20,28 @@ use Throwable;
 class GetEventsController extends QueryController
 {
     /**
-     *
-     * @OA\Response(
-     *     response=200,
-     *     description="Return events list",
-     *     ref="#/components/responses/events"
-     * )
-     * @OA\Response(
-     *     response=400,
-     *     description="Bad request",
-     *     @OA\JsonContent(ref="#/components/schemas/Error")
-     * )
-     * @OA\Response(
-     *     response=409,
-     *     description="Conflict"
-     * )
-     *
-     * @OA\Parameter(ref="#/components/parameters/page")
-     * @OA\Parameter(ref="#/components/parameters/limit")
-     *
-     * @OA\Tag(name="Events")
-     *
-     * @Security(name="Bearer")
-     *
      * @throws AssertionFailedException
      * @throws Throwable
      */
-    #[Route(path: '/events', name: 'events', methods: ['GET'])]
+    #[OA\Response(
+        ref: '#/components/responses/events',
+        response: Response::HTTP_OK,
+        description: 'Return events list'
+    )]
+    #[OA\Response(
+        response: Response::HTTP_BAD_REQUEST,
+        description: 'Bad request',
+        content: new OA\JsonContent(ref: '#/components/schemas/Error')
+    )]
+    #[OA\Response(
+        response: Response::HTTP_CONFLICT,
+        description: 'Conflict'
+    )]
+    #[OA\Parameter(ref: '#/components/parameters/page')]
+    #[OA\Parameter(ref: '#/components/parameters/limit')]
+    #[OA\Tag(name: 'Events')]
+    #[Security(name: 'Bearer')]
+    #[Route(path: '/events', name: 'events', methods: [Request::METHOD_GET])]
     public function __invoke(Request $request): OpenApi
     {
         $page = $request->query->get('page', 1);

--- a/src/UI/Http/Rest/Controller/Healthz/HealthzController.php
+++ b/src/UI/Http/Rest/Controller/Healthz/HealthzController.php
@@ -6,29 +6,30 @@ namespace UI\Http\Rest\Controller\Healthz;
 
 use App\Shared\Infrastructure\Event\ReadModel\ElasticSearchEventRepository;
 use App\User\Infrastructure\ReadModel\Mysql\MysqlReadModelUserRepository;
+use Symfony\Component\HttpFoundation\Response;
 use UI\Http\Rest\Response\OpenApi;
-use OpenApi\Annotations as OA;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
 final class HealthzController
 {
-    public function __construct(private readonly ElasticSearchEventRepository $elasticSearchEventRepository, private readonly MysqlReadModelUserRepository $mysqlReadModelUserRepository)
-    {
+    public function __construct(
+        private readonly ElasticSearchEventRepository $elasticSearchEventRepository,
+        private readonly MysqlReadModelUserRepository $mysqlReadModelUserRepository
+    ){
     }
 
-    /**
-     * @OA\Response(
-     *     response=200,
-     *     description="OK"
-     * )
-     * @OA\Response(
-     *     response=500,
-     *     description="Something not ok"
-     * )
-     * @OA\Tag(name="Healthz")
-     */
-    #[Route(path: '/healthz', name: 'healthz', methods: ['GET'])]
+    #[OA\Response(
+        response: Response::HTTP_OK,
+        description: 'OK'
+    )]
+    #[OA\Response(
+        response: Response::HTTP_INTERNAL_SERVER_ERROR,
+        description: 'Something not ok'
+    )]
+    #[OA\Tag(name: 'Healthz')]
+    #[Route(path: '/healthz', name: 'healthz', methods: [Request::METHOD_GET])]
     public function __invoke(Request $request): OpenApi
     {
         $elastic = null;

--- a/src/UI/Http/Rest/Controller/User/GetUserByEmailController.php
+++ b/src/UI/Http/Rest/Controller/User/GetUserByEmailController.php
@@ -6,46 +6,39 @@ namespace UI\Http\Rest\Controller\User;
 
 use App\Shared\Application\Query\Item;
 use App\User\Application\Query\User\FindByEmail\FindByEmailQuery;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use UI\Http\Rest\Controller\QueryController;
 use UI\Http\Rest\Response\OpenApi;
 use Assert\Assertion;
 use Assert\AssertionFailedException;
 use Nelmio\ApiDocBundle\Annotation\Security;
-use OpenApi\Annotations as OA;
+use OpenApi\Attributes as OA;
 use Symfony\Component\Routing\Annotation\Route;
 use Throwable;
 
 final class GetUserByEmailController extends QueryController
 {
     /**
-     * @OA\Response(
-     *     response=200,
-     *     description="Returns the user of the given email",
-     *     ref="#/components/responses/users"
-     * )
-     * @OA\Response(
-     *     response=400,
-     *     description="Bad request"
-     * )
-     * @OA\Response(
-     *     response=404,
-     *     description="Not found"
-     * )
-     * @OA\RequestBody(
-     *     @OA\JsonContent(
-     *         type="object",
-     *         @OA\Property(property="email", type="string"),
-     *     )
-     * )
-     *
-     * @OA\Tag(name="User")
-     *
-     * @Security(name="Bearer")
-     *
      * @throws AssertionFailedException
      * @throws Throwable
      */
-    #[Route(path: '/user/{email}', name: 'find_user', methods: ['GET'])]
+    #[OA\Response(
+        ref: '#/components/responses/users',
+        response: Response::HTTP_OK,
+        description: 'Returns the user of the given email',
+    )]
+    #[OA\Response(
+        response: Response::HTTP_BAD_REQUEST,
+        description: 'Bad request',
+    )]
+    #[OA\Response(
+        response: Response::HTTP_NOT_FOUND,
+        description: 'Not found',
+    )]
+    #[OA\Tag(name: 'User')]
+    #[Security(name: 'Bearer')]
+    #[Route(path: '/user/{email}', name: 'find_user', methods: [Request::METHOD_GET])]
     public function __invoke(string $email): OpenApi
     {
         Assertion::email($email, "Email can\'t be empty or invalid");

--- a/src/UI/Http/Rest/Controller/User/SignUpController.php
+++ b/src/UI/Http/Rest/Controller/User/SignUpController.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace UI\Http\Rest\Controller\User;
 
 use App\User\Application\Command\SignUp\SignUpCommand;
+use Symfony\Component\HttpFoundation\Response;
 use UI\Http\Rest\Controller\CommandController;
 use UI\Http\Rest\Response\OpenApi;
 use Assert\Assertion;
 use Assert\AssertionFailedException;
-use OpenApi\Annotations as OA;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 use Throwable;
@@ -17,35 +18,33 @@ use Throwable;
 final class SignUpController extends CommandController
 {
     /**
-     *
-     * @OA\Response(
-     *     response=201,
-     *     description="User created successfully"
-     * )
-     * @OA\Response(
-     *     response=400,
-     *     description="Bad request"
-     * )
-     * @OA\Response(
-     *     response=409,
-     *     description="Conflict"
-     * )
-     * @OA\RequestBody(
-     *     @OA\Schema(type="object"),
-     *     @OA\JsonContent(
-     *         type="object",
-     *         @OA\Property(property="uuid", type="string"),
-     *         @OA\Property(property="email", type="string"),
-     *         @OA\Property(property="password", type="string")
-     *     )
-     * )
-     *
-     * @OA\Tag(name="User")
-     *
      * @throws AssertionFailedException
      * @throws Throwable
      */
-    #[Route(path: '/signup', name: 'user_create', methods: ['POST'])]
+    #[OA\Response(
+        response: Response::HTTP_CREATED,
+        description: 'User created successfully',
+    )]
+    #[OA\Response(
+        response: Response::HTTP_BAD_REQUEST,
+        description: 'Bad request',
+    )]
+    #[OA\Response(
+        response: Response::HTTP_CONFLICT,
+        description: 'Conflict',
+    )]
+    #[OA\RequestBody(
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'uuid', type: 'string', format: 'uuid'),
+                new OA\Property(property: 'email', type: 'string', format: 'email'),
+                new OA\Property(property: 'password', type: 'string', format: 'string'),
+            ],
+            type: 'object',
+        )
+    )]
+    #[OA\Tag(name: 'User')]
+    #[Route(path: '/signup', name: 'user_create', methods: [Request::METHOD_POST])]
     public function __invoke(Request $request): OpenApi
     {
         $uuid = (string) $request->request->get('uuid');

--- a/src/UI/Http/Rest/Controller/User/UserChangeEmailController.php
+++ b/src/UI/Http/Rest/Controller/User/UserChangeEmailController.php
@@ -7,12 +7,13 @@ namespace UI\Http\Rest\Controller\User;
 use App\Shared\Application\Command\CommandBusInterface;
 use App\User\Application\Command\ChangeEmail\ChangeEmailCommand;
 use App\User\Domain\Exception\ForbiddenException;
+use Symfony\Component\HttpFoundation\Response;
 use UI\Http\Rest\Controller\CommandController;
 use UI\Http\Session;
 use Assert\Assertion;
 use Assert\AssertionFailedException;
 use Nelmio\ApiDocBundle\Annotation\Security;
-use OpenApi\Annotations as OA;
+use OpenApi\Attributes as OA;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,40 +28,37 @@ final class UserChangeEmailController extends CommandController
     }
 
     /**
-     *
-     * @OA\Response(
-     *     response=201,
-     *     description="Email changed"
-     * )
-     * @OA\Response(
-     *     response=400,
-     *     description="Bad request"
-     * )
-     * @OA\Response(
-     *     response=409,
-     *     description="Conflict"
-     * )
-     *
-     * @OA\RequestBody(
-     *     @OA\JsonContent(
-     *         type="object",
-     *         @OA\Property(property="email", type="string"),
-     *     )
-     * )
-     *
-     * @OA\Parameter(
-     *     name="uuid",
-     *     in="path",
-     *     @OA\Schema(type="string")
-     * )
-     *
-     * @OA\Tag(name="User")
-     * @Security(name="Bearer")
-     *
      * @throws AssertionFailedException
      * @throws Throwable
      */
-    #[Route(path: '/users/{uuid}/email', name: 'user_change_email', methods: ['POST'])]
+    #[OA\Response(
+        response: Response::HTTP_CREATED,
+        description: 'Email changed'
+    )]
+    #[OA\Response(
+        response: Response::HTTP_BAD_REQUEST,
+        description: 'Bad request'
+    )]
+    #[OA\Response(
+        response: Response::HTTP_CONFLICT,
+        description: 'Conflict',
+    )]
+    #[OA\RequestBody(
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'email', type: 'string', format: 'email')
+            ],
+            type: 'object'
+        )
+    )]
+    #[OA\Parameter(
+        name: 'uuid',
+        in: 'path',
+        schema: new OA\Schema(type: 'string', format: 'uuid')
+    )]
+    #[OA\Tag(name: 'User')]
+    #[Security(name: 'Bearer')]
+    #[Route(path: '/users/{uuid}/email', name: 'user_change_email', methods: [Request::METHOD_POST])]
     public function __invoke(string $uuid, Request $request): JsonResponse
     {
         $this->validateUuid($uuid);


### PR DESCRIPTION
I discovered that some annotations were duplicated, so here is a pull request to address the issue.
Additionally I've improved schemas a little bit by using correct format, used Response/Request consts and changed annotations to attributes since PHP 8.1 is minimum compatible version.

The duplication caused a Nelmio 500 error, as shown in the screenshot below.
<img width="1086" alt="image" src="https://github.com/user-attachments/assets/625933a2-f4f3-4a12-9405-99e5a602e977">
